### PR TITLE
Add keymap validation step to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,14 @@
+
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
+  validate_keymap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate keymap.json
+        run: python scripts/validate_keymap.py
+
   build:
+    needs: validate_keymap
     uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main

--- a/scripts/validate_keymap.py
+++ b/scripts/validate_keymap.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+
+KEYMAP_PATH = Path(__file__).resolve().parents[1] / "config" / "keymap.json"
+
+def main():
+    with open(KEYMAP_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    layer_names = data.get("layer_names")
+    layers = data.get("layers")
+
+    if layer_names is None or layers is None:
+        raise KeyError("layer_names or layers missing in keymap.json")
+
+    assert len(layer_names) == len(layers), (
+        f"Mismatch: {len(layer_names)} layer names vs {len(layers)} layers")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to check that `layer_names` and `layers` arrays match length
- run the validation in CI before the ZMK build job

## Testing
- `python scripts/validate_keymap.py` *(fails: Mismatch: 8 layer names vs 6 layers)*

------
https://chatgpt.com/codex/tasks/task_e_683fb7b38b5c8323bee061c62a98975e