### PR TITLE
Fix layer names list

### DIFF
--- a/config/keymap.json
+++ b/config/keymap.json
@@ -7,10 +7,8 @@
     "mac_code_layer",
     "unused_layer",
     "mac_function_layer",
-    "windows_default_layer",
-    "windows_code_layer",
-    "windows_number_layer",
-    "windows_function_layer"
+    "yabai_layer",
+    "function_key_bt_layer"
   ],
   "layers": [
     [


### PR DESCRIPTION
## Summary
- remove windows layer names from `keymap.json`
- add yabai and bluetooth function key layers

## Testing
- `jq empty config/keymap.json`


------
https://chatgpt.com/codex/tasks/task_e_683fb794dd5083239158da4604691828