### PR TITLE
docs: update sleep timeout comment

### DIFF
--- a/config/corne.conf
+++ b/config/corne.conf
@@ -15,7 +15,7 @@ CONFIG_ZMK_DISPLAY=y
 
 
 #CONFIG_ZMK_MOUSE=y
-# Set deep sleep to 30 minutes
+# Set deep sleep to 60 minutes
 CONFIG_ZMK_SLEEP=y
 CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=3600000
 


### PR DESCRIPTION
## Summary
- fix deep sleep comment to match timeout in `corne.conf`

## Testing
- `grep -n "deep sleep" -n config/corne.conf`

------
https://chatgpt.com/codex/tasks/task_e_683fb7a8cba083238259f232524a6cd7